### PR TITLE
Sample to read from a json file and issue individual createIndex commands on each field and nested field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.azure.cosmosdb.mongodb-data-indexer</groupId>
+    <artifactId>azure-cosmosdb-mongo-data-indexer</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven-compiler-plugin.source>21</maven-compiler-plugin.source>
+        <maven-compiler-plugin.target>21</maven-compiler-plugin.target>
+        <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+        <mongodb-driver-sync.version>5.0.0</mongodb-driver-sync.version>
+        <mongodb-crypt.version>1.8.0</mongodb-crypt.version>
+        <!-- Keeping 1.2.13 until mongodb-crypt makes slf4j-api an optional dependency -->
+        <!-- https://jira.mongodb.org/browse/MONGOCRYPT-602 -->
+        <logback-classic.version>1.2.13</logback-classic.version>
+        <exec-maven-plugin.version>3.1.1</exec-maven-plugin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>${mongodb-driver-sync.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-crypt</artifactId>
+            <version>${mongodb-crypt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback-classic.version}</version>
+        </dependency>
+        <dependency>
+    		<groupId>javax.json</groupId>
+    		<artifactId>javax.json-api</artifactId>
+    		<version>1.1.4</version>
+		</dependency>
+		<dependency>
+		    <groupId>org.glassfish</groupId>
+		    <artifactId>javax.json</artifactId>
+		    <version>1.1</version>
+		</dependency>
+		<dependency>
+    		<groupId>org.apache.logging.log4j</groupId>
+    		<artifactId>log4j-api</artifactId>
+    		<version>2.9.0</version>
+		</dependency>
+		<dependency>
+		    <groupId>ch.qos.logback</groupId>
+		    <artifactId>logback-classic</artifactId>
+			<version>1.2.3</version>
+		</dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>${maven-compiler-plugin.source}</source>
+                    <target>${maven-compiler-plugin.target}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <!-- Adding this plugin, so we don't need to add -Dexec.cleanupDaemonThreads=false in the mvn cmd line -->
+                <!-- to avoid the IllegalThreadStateException when running with Maven -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${exec-maven-plugin.version}</version>
+                <configuration>
+                    <cleanupDaemonThreads>false</cleanupDaemonThreads>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/cosmosdb/mongodb/vcore/dataindexer/Indexer.java
+++ b/src/main/java/com/cosmosdb/mongodb/vcore/dataindexer/Indexer.java
@@ -1,0 +1,58 @@
+package com.cosmosdb.mongodb.vcore.dataindexer;
+
+import org.bson.Document;
+
+import com.mongodb.MongoSocketReadException;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Indexes;
+
+public class Indexer implements Runnable {
+
+	/**
+	 * The field (including as many levels of nesting as needed) to be indexed for the first time
+	 */
+    private String fieldToBeIndexed;
+    
+    /**
+     * The MongoCollection instance through which the indexing operation needs to be executed
+     */
+    private MongoCollection<Document> collection;
+    
+    public Indexer(String fieldToBeIndexed, MongoCollection<Document> collection) {
+        this.fieldToBeIndexed = fieldToBeIndexed;
+        this.collection = collection;
+    }
+    
+    /**
+     * Indexes the specific field as an independent thread.
+     * 
+     * The purpose behind this is to circumvent the scenario where a field when indexed for the first time,
+     * does not get a response back from the vCore server until the indexing has been completed across
+     * all existing documents in the collection.
+     * 
+     * This can be a time consuming effort when a large amount of data has already been ingested.
+     * 
+     * Thus, this avoids having to index each field one after the other until completion.
+     * 
+     * This is the equivalent of a fire and forget operation for all the fields that need to be indexed.
+     */
+    @Override
+    public void run() {
+        System.out.println(
+            "About to create an index on field " + 
+            this.fieldToBeIndexed + 
+            "on thread: " + 
+            Thread.currentThread().getName());
+        
+        try {
+        	collection.createIndex(Indexes.ascending(this.fieldToBeIndexed));
+        } catch (MongoSocketReadException ex) {
+        	System.out.println(
+        		"Done creating the index on field: " + 
+        	    this.fieldToBeIndexed + 
+        	    " ignoring MongoSocketReadException");
+        }
+        
+        System.out.println("Done creating an index on field" + this.fieldToBeIndexed); 
+    }
+}

--- a/src/main/java/com/cosmosdb/mongodb/vcore/dataindexer/ReIndex.java
+++ b/src/main/java/com/cosmosdb/mongodb/vcore/dataindexer/ReIndex.java
@@ -1,0 +1,83 @@
+package com.cosmosdb.mongodb.vcore.dataindexer;
+
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.bson.Document;
+import org.slf4j.LoggerFactory;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.cosmosdb.mongodb.vcore.filereader.SampleJSONFileReader;
+import com.cosmosdb.mongodb.vcore.json.parser.JsonParser;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+
+public class ReIndex {
+
+	/**
+     * Connection String for the Cosmos DB for MongoDB vCore cluster
+     */
+    private static String MongovCoreConnectionString;
+    
+    /**
+     * The database within which the documents will be inserted for the benchmarking run.
+     */
+    private static String MongovCoreDatabase;
+    
+    /**
+     * The collection into which the documents will be inserted for the benchmarking run.
+     */
+    private static String MongovCoreCollection;
+    
+    /**
+     * The path to the local json file to be parsed and each field and nested field to be indexed.
+     */
+    private static String SampleJsonFilePath;
+    
+    public static void main(String[] args) throws InterruptedException {
+    	
+    	((LoggerContext) LoggerFactory.getILoggerFactory()).getLogger("org.mongodb.driver").setLevel(Level.ERROR);
+    	
+    	if (args.length > 0) {
+    		MongovCoreConnectionString = args[0];
+    	} if (args.length > 1) {
+    		MongovCoreDatabase = args[1];
+    	} if (args.length > 2) {
+    		MongovCoreCollection = args[2];
+    	} if (args.length > 3) {
+    		SampleJsonFilePath = args[3];
+    	}
+    	
+    	SampleJSONFileReader sampleFileReader = new SampleJSONFileReader();
+    	String jsonDocument = sampleFileReader.getJSONStringFromSampleFile(SampleJsonFilePath);
+    	
+    	JsonParser jsonParser = new JsonParser(jsonDocument);
+    	Set<String> eachPathToIndex = jsonParser.parseJson();
+    	
+    	try (MongoClient mongoClient = MongoClients.create(MongovCoreConnectionString)) {
+        	MongoDatabase database = mongoClient.getDatabase(MongovCoreDatabase);
+        	MongoCollection<Document> collection = database.getCollection(MongovCoreCollection);
+        	
+        	ExecutorService es = Executors.newCachedThreadPool();
+        	
+        	for (String eachNestedPath : eachPathToIndex) {
+    			System.out.println(eachNestedPath);
+    			
+    			Indexer fireAndForgetIndexer = new Indexer(eachNestedPath, collection);
+    			es.execute(new Thread(fireAndForgetIndexer));
+    		}
+    		
+    		es.shutdown();
+    		
+    		// Wait for 2 minutes before exiting all threads
+            while (!es.awaitTermination(2*60*1000, TimeUnit.MILLISECONDS)) {
+            }
+        }
+    }
+}

--- a/src/main/java/com/cosmosdb/mongodb/vcore/filereader/SampleJSONFileReader.java
+++ b/src/main/java/com/cosmosdb/mongodb/vcore/filereader/SampleJSONFileReader.java
@@ -1,0 +1,36 @@
+package com.cosmosdb.mongodb.vcore.filereader;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+
+public class SampleJSONFileReader {
+	
+	public SampleJSONFileReader() {
+		
+	}
+	
+	/**
+	 * Simply reads the contents of the specified JSON file and returns the contents of the file as a string.
+	 * 
+	 * This method does NOT valid that the specified field contains a valid JSON.
+	 * 
+	 * @param jsonFilePath - The local path of the sample JSON file
+	 * 
+	 * @return The contents of the sample file as a string
+	 */
+	public String getJSONStringFromSampleFile(String jsonFilePath) {
+		StringBuilder jsonStringBuilder = new StringBuilder();
+		try (BufferedReader br = new BufferedReader(new FileReader(jsonFilePath))) {
+			String line;
+		    while ((line = br.readLine()) != null) {
+		        jsonStringBuilder.append(line);
+		    }
+		} catch (IOException e) {
+		    e.printStackTrace();
+		}
+		
+		return jsonStringBuilder.toString();
+	}
+
+}

--- a/src/main/java/com/cosmosdb/mongodb/vcore/json/parser/JsonParser.java
+++ b/src/main/java/com/cosmosdb/mongodb/vcore/json/parser/JsonParser.java
@@ -1,0 +1,69 @@
+package com.cosmosdb.mongodb.vcore.json.parser;
+
+import java.io.StringReader;
+import java.util.LinkedHashSet;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonReader;
+import javax.json.JsonValue;
+
+public class JsonParser {
+
+	private String jsonDocument;
+	
+	public JsonParser(String jsonDocument) {
+		this.jsonDocument = jsonDocument;
+	}
+	
+	public Set<String> parseJson() {
+		JsonReader jsonReader = Json.createReader(new StringReader(this.jsonDocument));
+		JsonValue jValue = jsonReader.readValue();
+		
+		Set<String> nestedPaths = new LinkedHashSet<>();
+		getRecursivePaths(jValue, "", nestedPaths);
+		
+		return nestedPaths;
+	}
+	
+	private void getRecursivePaths(JsonValue jsonObjectToTraverse, String rootPath, Set<String> nestedPaths) {
+		
+		switch(jsonObjectToTraverse.getValueType()) {
+			case OBJECT:
+				String rootPathForObject = "";
+				
+				for (Entry<String, JsonValue> eachEntryInObject : jsonObjectToTraverse.asJsonObject().entrySet()) {
+					
+					if(rootPath.length() == 0) {
+						rootPathForObject = eachEntryInObject.getKey();
+					} else {
+						rootPathForObject = rootPath + "." + eachEntryInObject.getKey();
+					}
+					
+					getRecursivePaths(eachEntryInObject.getValue(), rootPathForObject, nestedPaths);
+				}
+				break;
+				
+			case ARRAY:
+				JsonArray jArray = jsonObjectToTraverse.asJsonArray();
+				
+				for (JsonValue eachValueInArray : jArray) {
+					getRecursivePaths(eachValueInArray, rootPath, nestedPaths);
+				}
+				break;
+				
+			case STRING:				
+			case NUMBER:				
+			case TRUE:				
+			case FALSE:				
+			case NULL:
+				nestedPaths.add(rootPath);
+				break;
+				
+			default:
+				break;
+		}
+	}
+}


### PR DESCRIPTION
This commit contains the following:
1. File reader that parses a JSON to extract all the fields and nested fields
2. Builds the paths as they need to be indexed into an Azure Cosmos DB for MongoDB vCore cluster
3. Issues individual createIndex commands on each path using an asynchronous operation that does not block on each index to complete on a historical data load.